### PR TITLE
Add basic custom error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+pub enum OauthError {
+    TokenRequestFailed,
+    AuthUrlCreationFailed,
+}


### PR DESCRIPTION
At the moment, this crate is using `unwrap()` in several places, which should never happen in library code, since the choice wheter to crash or not should be up the application developer. 
This PR aims at adding an expandible custom error type that gets returned instead of the expected data if the function returning it fails at any point. This is much more graceful and flexible rather than making the "user" program crash 