### PR TITLE
task: make tokio a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 [dependencies]
 async-trait = "0.1.80"
 oauth2 = "4.4.2"
-tokio = { version = "1.37.0", features = ["full"] }
 
 [dev-dependencies]
 serde = "1.0.198"
+tokio = { version = "1.37.0", features = ["full"] }
 axum = { version = "0.7.5", features = ["macros"] }
 tokio-postgres = "0.7.10"
 dotenv = "0.15.0"


### PR DESCRIPTION
This PR moves `tokio` to `dev-dependencies` as is only used on examples code path, making it build faster and leaner when used as a library.